### PR TITLE
Fixes an issue with duplicate attachments disappearing

### DIFF
--- a/db/attachment.go
+++ b/db/attachment.go
@@ -80,7 +80,7 @@ func (db *Database) storeAttachments(doc *document, body Body, generation int, p
 
 			key := fmt.Sprintf("%s/%s/%s/%s/%s", organization, entityType, docId, name, strings.Replace(digest, "/", "_", -1))
 
-			newAttachmentData[AttachmentKey(digest)] = Attachment {
+			newAttachmentData[AttachmentKey(key)] = Attachment {
 				Key: key,
 				ContentType: "image/jpeg",
 				Data: attachment,


### PR DESCRIPTION
If you attached the same file to a document under different attachment names, only one would win out because the intermediate dictionary was storing them by digest and not attachment name. Retrieving all but the last attachment would fail because they are retrieved by attachment name, not digest.